### PR TITLE
Add missing limits header

### DIFF
--- a/code/vkutils.hpp
+++ b/code/vkutils.hpp
@@ -9,6 +9,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <limits>
 
 #include <vulkan/vulkan.hpp>
 


### PR DESCRIPTION
Using clang 14 on Ubuntu the build fails with

```
vkutils.hpp:346:35: error: no member named 'numeric_limits' in namespace 'std'
                             std::numeric_limits<uint64_t>::max()) !=
```